### PR TITLE
BUGFIX: Limit search to document nodeTypes

### DIFF
--- a/Resources/Private/TypoScript/SearchPlugin.ts2
+++ b/Resources/Private/TypoScript/SearchPlugin.ts2
@@ -2,7 +2,7 @@ prototype(Flowpack.SearchPlugin:Search) < prototype(TYPO3.Neos:Content) {
 	templatePath = 'resource://Flowpack.SearchPlugin/Private/Templates/NodeTypes/Search.html'
 
 	searchTerm = ${request.arguments.search}
-	searchQuery = ${this.searchTerm ? Search.query(site).fulltext(this.searchTerm) : null}
+	searchQuery = ${this.searchTerm ? Search.query(site).fulltext(this.searchTerm).nodeType('TYPO3.Neos:Document') : null}
 
 	totalSearchResults = ${this.searchQuery.count()}
 


### PR DESCRIPTION
The SearchPlugin outputs all kinds of nodeTypes (e.g.
ContentCollections) in the search results. Content nodeTypes have no URL
and therefore are not linkable.

By limiting the `searchQuery` to only include `TYPO3.Neos:Document`
nodeTypes we ensure all search results are linkable ond no internal
elements (like "contentRight", "sidebar") are included.