### PR TITLE
!!! TASK: Improve suggestion results

### DIFF
--- a/Classes/Flowpack/SearchPlugin/EelHelper/SuggestionHelper.php
+++ b/Classes/Flowpack/SearchPlugin/EelHelper/SuggestionHelper.php
@@ -1,0 +1,56 @@
+<?php
+namespace Flowpack\SearchPlugin\EelHelper;
+
+/*
+ * This file is part of the Flowpack.SearchPlugin package.
+ *
+ * (c) Contributors of the Flowpack Team - flowpack.org
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Eel\ProtectedContextAwareInterface;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+
+/**
+ * Helper for building suggestion configurations
+ *
+ * @Flow\Proxy(false)
+ */
+class SuggestionHelper implements ProtectedContextAwareInterface
+{
+
+    /**
+     * @param string $text
+     * @param NodeInterface $node
+     * @param int $weight
+     * @return array
+     */
+    public function buildConfig($text, NodeInterface $node, $weight = 1)
+    {
+        $text = strip_tags($text);
+
+        return [
+            'input' => explode(' ', preg_replace("/[^[:alnum:][:space:]]/u", " ", $text)),
+            'output' => $text,
+//            'payload' => [
+//                'nodeIdentifier' => $node->getIdentifier(),
+//            ],
+            'weight' => $weight,
+        ];
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -4,3 +4,69 @@
   ui:
     label: 'Search'
     icon: 'icon-search'
+
+'TYPO3.Neos:Document':
+  properties:
+    '__suggestions':
+      search:
+        elasticSearchMapping:
+          type: completion
+          context:
+            workspace:
+              type: category
+              path: '__workspace'
+            parentPath:
+              type: category
+              path: '__parentPath'
+            dimensionCombinationHash:
+              type: category
+              path: '__dimensionCombinationHash'
+        indexing: '${Flowpack.SearchPlugin.Suggestion.buildConfig(node.properties.title, node, 3)}'
+    '__completion':
+      search:
+        elasticSearchMapping:
+          type: string
+          analyzer: autocomplete
+        indexing: '${node.properties.title}'
+
+'TYPO3.Neos.NodeTypes:Text':
+  properties:
+    '__completion':
+      search:
+        elasticSearchMapping:
+          type: string
+          analyzer: autocomplete
+        indexing: '${node.properties.text}'
+
+'TYPO3.Neos.NodeTypes:Headline':
+  properties:
+    '__suggestions':
+      search:
+        elasticSearchMapping:
+          type: completion
+          context:
+            workspace:
+              type: category
+              path: '__workspace'
+            parentPath:
+              type: category
+              path: '__parentPath'
+            dimensionCombinationHash:
+              type: category
+              path: '__dimensionCombinationHash'
+        indexing: '${Flowpack.SearchPlugin.Suggestion.buildConfig(node.properties.title, node, 1)}'
+    '__completion':
+      search:
+        elasticSearchMapping:
+          type: string
+          analyzer: autocomplete
+        indexing: '${node.properties.title}'
+
+'TYPO3.Neos.NodeTypes:TextWithImage':
+  properties:
+    '__completion':
+      search:
+        elasticSearchMapping:
+          type: string
+          analyzer: autocomplete
+        indexing: '${node.properties.text}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,3 +7,26 @@ TYPO3:
   TypoScript:
     defaultContext:
       Flowpack.SearchPlugin.Array: 'Flowpack\SearchPlugin\EelHelper\SearchArrayHelper'
+
+  TYPO3CR:
+    Search:
+      defaultContext:
+        Flowpack.SearchPlugin.Suggestion: 'Flowpack\SearchPlugin\EelHelper\SuggestionHelper'
+
+Flowpack:
+  ElasticSearch:
+    indexes:
+      default:
+        typo3cr:
+          analysis:
+            filter:
+              autocompleteFilter:
+                max_shingle_size: 5
+                min_shingle_size: 2
+                type: 'shingle'
+            analyzer:
+              autocomplete:
+                filter: [ 'lowercase', 'autocompleteFilter' ]
+                char_filter: [ 'html_strip' ]
+                type: 'custom'
+                tokenizer: 'standard'

--- a/Resources/Private/Templates/NodeTypes/Search.Form.html
+++ b/Resources/Private/Templates/NodeTypes/Search.Form.html
@@ -1,4 +1,4 @@
 <form method="GET">
-    <input type="search" name="search" value="{searchWord}" placeholder="{f:translate(id: 'search', package: 'Flowpack.SearchPlugin')}" data-autocomplete-source="{f:uri.action(action: 'index', controller: 'Suggest', package: 'Flowpack.SearchPlugin', format: 'json', absolute: 1)}"/>
+    <input type="search" name="search" value="{searchWord}" placeholder="{f:translate(id: 'search', package: 'Flowpack.SearchPlugin')}" data-autocomplete-source="{f:uri.action(action: 'index', controller: 'Suggest', package: 'Flowpack.SearchPlugin', format: 'json', absolute: 1, arguments: {contextNode: site})}"/>
     <button type="submit">{f:translate(id: 'search', package: 'Flowpack.SearchPlugin')}</button>
 </form>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "typo3-flow-package",
     "description": "Add description here",
     "require": {
-        "typo3/flow": "*"
+        "flowpack/elasticsearch-contentrepositoryadaptor": "^2.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
With this change the SuggestController can now
better be used for autocompletion. It respects the
context nodes dimensions, workspace and path.

More context variables could be added for security.
If no completions are found fuzzy suggestions are returned.

This change also adds the dependency to ES for this package
which makes sense anyway.
