### PR TITLE
BUGFIX: Neos.Neos.typoScript.autoInclude -> Neos.Neos.fusion.autoInclude

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,7 +1,7 @@
 
 Neos:
   Neos:
-    typoScript:
+    fusion:
       autoInclude:
         Flowpack.SearchPlugin: true
   Fusion:


### PR DESCRIPTION
auto include is not working with the current configuration