### PR TITLE
BUGFIX: Support Array as Suggestion input

### DIFF
--- a/Classes/EelHelper/SuggestionIndexHelper.php
+++ b/Classes/EelHelper/SuggestionIndexHelper.php
@@ -11,6 +11,7 @@ namespace Flowpack\SearchPlugin\EelHelper;
  * source code.
  */
 
+use Flowpack\SearchPlugin\Exception;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
@@ -21,9 +22,8 @@ use Neos\Flow\Annotations as Flow;
  */
 class SuggestionIndexHelper implements ProtectedContextAwareInterface
 {
-
     /**
-     * @param string $input The input to store, this can be a an array of strings or just a string. This field is mandatory.
+     * @param string|array $input The input to store, this can be a an array of strings or just a string. This field is mandatory.
      * @param string $output The result is de-duplicated if several documents have the same output, i.e. only one is returned as part of the suggest result.
      * @param array $payload An arbitrary JSON object, which is simply returned in the suggest option.
      * @param int $weight A positive integer or a string containing a positive integer, which defines a weight and allows you to rank your suggestions.
@@ -40,13 +40,30 @@ class SuggestionIndexHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * @param string $input
+     * @param string|array $input
      * @return array
+     * @throws Exception
      */
     protected function prepareInput($input)
     {
-        $input = preg_replace( "/\r|\n/", '', $input);
-        return array_values(array_filter(explode(' ', preg_replace("/[^[:alnum:][:space:]]/u", ' ', strip_tags($input)))));
+        $process = function ($input) {
+            if (!\is_string($input)) {
+                throw new Exception('Only string are supported as input', 1512733297);
+            }
+            $input = preg_replace("/\r|\n/", '', $input);
+            return array_values(array_filter(explode(' ', preg_replace("/[^[:alnum:][:space:]]/u", ' ', strip_tags($input)))));
+        };
+        if (\is_string($input)) {
+            return $process($input);
+        } elseif (\is_array($input)) {
+            $data = [];
+            foreach (array_map($process, $input) as $values) {
+                $data = \array_merge($data, $values);
+            }
+            return $data;
+        } else {
+            throw new Exception('Only string or array are supported as input', 1512733287);
+        }
     }
 
     /**

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Flowpack\SearchPlugin;
+
+/*
+ * This file is part of the Flowpack.SearchPlugin package.
+ *
+ * (c) Contributors of the Flowpack Team - flowpack.org
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class Exception extends \Neos\Flow\Exception
+{
+
+}


### PR DESCRIPTION
The PHP doc of the method said that `$input` can be a string or an array, but the processing does not support array values.