### PR TITLE
TASK: Update docs with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # Flowpack.SearchPlugin
 
 This plugin is a Search Plugin, to be used together with
-[Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor).
+* [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor) or 
+* [Flowpack.SimpleSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.SimpleSearch.ContentRepositoryAdaptor).
 
 ## Installation
+Install via composer with your favorite adaptor:
+
+**ElasticSearch**
+```
+composer require flowpack/searchplugin flowpack/elasticsearch-contentrepositoryadaptor
+```
+
+**SimpleSearch**
+```
+composer require flowpack/searchplugin flowpack/simplesearch-contentrepositoryadaptor
+```
 
 Inclusion of the routes from this package into your main `Configuration/Routes.yaml` is no longer needed as of Flow 4.0.
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ This plugin is a Search Plugin, to be used together with
 * [Flowpack.SimpleSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.SimpleSearch.ContentRepositoryAdaptor).
 
 ## Installation
+
 Install via composer with your favorite adaptor:
 
 **ElasticSearch**
-```
-composer require flowpack/searchplugin flowpack/elasticsearch-contentrepositoryadaptor
-```
+
+    composer require flowpack/searchplugin flowpack/elasticsearch-contentrepositoryadaptor
 
 **SimpleSearch**
-```
-composer require flowpack/searchplugin flowpack/simplesearch-contentrepositoryadaptor
-```
+
+    composer require flowpack/searchplugin flowpack/simplesearch-contentrepositoryadaptor
 
 Inclusion of the routes from this package into your main `Configuration/Routes.yaml` is no longer needed as of Flow 4.0.
 


### PR DESCRIPTION
The hard dependency to the Flowpack.ElasticSearch.ContentRepositoryAdaptor has been removed. Now you have to install the corresponding adaptor on your own. The new installation instructions shall call attention and provide guidance.