### PR TITLE
TASK: Remove duplicate Elasticsearch check

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -178,10 +178,8 @@ class SuggestController extends ActionController
      */
     protected function extractSuggestions($response)
     {
-        if ($this->elasticSearchClient === null) {
-            throw new \RuntimeException('The SuggestController needs an ElasticSearchClient, it seems you run without the flowpack/elasticsearch-contentrepositoryadaptor package, though.', 1487189823);
-        }
         $suggestionOptions = isset($response['suggest']) ? $response['suggest'] : [];
+
         if (count($suggestionOptions['suggestions'][0]['options']) > 0) {
             return $suggestionOptions['suggestions'][0]['options'];
         }


### PR DESCRIPTION
The check in `extractSuggestions` is not needed, the method

- as such does not rely on Elasticsearch
- will not be called unless Elasticsearch is used (check in `indexAction`)