### PR TITLE
BUGFIX: Handle null title in suggestion indexing

### DIFF
--- a/Configuration/NodeTypes.Mixins.yaml
+++ b/Configuration/NodeTypes.Mixins.yaml
@@ -16,7 +16,7 @@
             dimensionCombinationHash:
               type: category
               path: '__dimensionCombinationHash'
-        indexing: "${Flowpack.SearchPlugin.Suggestion.build(q(node).property('title'), q(node).is('[instanceof Neos.Neos:Document]') ? node.identifier : q(node).parents('[instanceof Neos.Neos:Document]').get(0).identifier, {nodeIdentifier: node.identifier}, 20)}"
+        indexing: "${Flowpack.SearchPlugin.Suggestion.build(q(node).property('title') ? q(node).property('title') : '', q(node).is('[instanceof Neos.Neos:Document]') ? node.identifier : q(node).parents('[instanceof Neos.Neos:Document]').get(0).identifier, {nodeIdentifier: node.identifier}, 20)}"
 
 'Flowpack.SearchPlugin:AutocompletableMixin':
   abstract: true


### PR DESCRIPTION
If the `title` has a `null` value for some reason, the helper will throw
an exception. This avoids that by passing an empty string instead.