### PR TITLE
TASK: add nodetype filter to suggest controller

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -58,11 +58,12 @@ class SuggestController extends ActionController
     /**
      * @param string $contextNodeIdentifier
      * @param string $dimensionCombination
+     * @param string $nodeType
      * @param string $term
      * @return void
      * @throws QueryBuildingException
      */
-    public function indexAction($contextNodeIdentifier, $dimensionCombination, $term)
+    public function indexAction($contextNodeIdentifier, $dimensionCombination, $term, $nodeType = 'Neos.Neos:Node')
     {
         if ($this->elasticSearchClient === null) {
             throw new \RuntimeException('The SuggestController needs an ElasticSearchClient, it seems you run without the flowpack/elasticsearch-contentrepositoryadaptor package, though.', 1487189823);
@@ -79,7 +80,7 @@ class SuggestController extends ActionController
             return;
         }
 
-        $requestJson = $this->buildRequestForTerm($contextNodeIdentifier, $dimensionCombination, $term);
+        $requestJson = $this->buildRequestForTerm($contextNodeIdentifier, $dimensionCombination, $term, $nodeType);
 
         try {
             $response = $this->elasticSearchClient->getIndex()->request('POST', '/_search', [], $requestJson)->getTreatedContent();
@@ -96,10 +97,11 @@ class SuggestController extends ActionController
      * @param string $term
      * @param string $contextNodeIdentifier
      * @param string $dimensionCombination
+     * @param string $nodeType
      * @return ElasticSearchQueryBuilder
      * @throws QueryBuildingException
      */
-    protected function buildRequestForTerm($contextNodeIdentifier, $dimensionCombination, $term)
+    protected function buildRequestForTerm($contextNodeIdentifier, $dimensionCombination, $term, $nodeType)
     {
         $cacheKey = $contextNodeIdentifier . '-' . md5($dimensionCombination);
         $termPlaceholder = '---term-soh2gufuNi---';
@@ -116,6 +118,7 @@ class SuggestController extends ActionController
             /** @var ElasticSearchQueryBuilder $query */
             $query = $this->elasticSearchQueryBuilder->query($contextNode);
             $query
+                ->nodeType($nodeType)
                 ->queryFilter('prefix', [
                     '__completion' => $termPlaceholder
                 ])


### PR DESCRIPTION
What do you think about adding a nodetype filter to the suggest controller?

I often use an `abstract` NodeType like `Site.Package:Mixin.Searchable` to whitelist nodetypes that should be shown/searchable via site search and I don't want completions or suggestions for all indexed documents.

I chose `Neos.Neos:Node` as default NodeType to avoid a breaking change here. However I think `Neos.Neos:Document` as default would probably be the better choice here.