### PR TITLE
BUGFIX: Prevent exception when term is empty

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -62,7 +62,7 @@ class SuggestController extends ActionController
      * @return void
      * @throws QueryBuildingException
      */
-    public function indexAction($term, $contextNodeIdentifier, $dimensionCombination = null)
+    public function indexAction($term = '', $contextNodeIdentifier, $dimensionCombination = null)
     {
         if ($this->elasticSearchClient === null) {
             throw new \RuntimeException('The SuggestController needs an ElasticSearchClient, it seems you run without the flowpack/elasticsearch-contentrepositoryadaptor package, though.', 1487189823);


### PR DESCRIPTION
I regularly see exceptions in the logs that `term` is not set.
I'm not sure how users accomplish this, but this should not cause an 
exception but simply return an empty list of suggestions.