### PR TITLE
TASK: Use more fine-grained sanitation

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -114,8 +114,8 @@ class SuggestController extends ActionController
         $term = strtolower($term);
 
         // The suggest function only works well with one word
-        // and the term is trimmed to alnum characters to avoid errors
-        $suggestTerm = preg_replace('/[[:^alnum:]]/', '', explode(' ', $term)[0]);
+        // special search characters are escaped
+        $suggestTerm = str_replace(['=', '>', '<', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/'], ['', '', '', '(', '\)', '\{', '\}', '[', '\]', '\^', '\"', '\~', '\*', '\?', '\:', '\\\\', '\/'], explode(' ', $term)[0]);
 
         if (!$this->elasticSearchQueryTemplateCache->has($cacheKey)) {
             $contentContext = $this->createContentContext('live', $dimensionCombination ? json_decode($dimensionCombination, true) : []);

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -14,6 +14,7 @@ namespace Flowpack\SearchPlugin\Controller;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException;
+use Flowpack\SearchPlugin\Utility\Sanitation;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
@@ -115,7 +116,7 @@ class SuggestController extends ActionController
 
         // The suggest function only works well with one word
         // special search characters are escaped
-        $suggestTerm = str_replace(['=', '>', '<', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/'], ['', '', '', '(', '\)', '\{', '\}', '[', '\]', '\^', '\"', '\~', '\*', '\?', '\:', '\\\\', '\/'], explode(' ', $term)[0]);
+        $suggestTerm = Sanitation::sanitizeSearchInput(explode(' ', $term)[0]);
 
         if (!$this->elasticSearchQueryTemplateCache->has($cacheKey)) {
             $contentContext = $this->createContentContext('live', $dimensionCombination ? json_decode($dimensionCombination, true) : []);

--- a/Classes/EelHelper/SuggestionIndexHelper.php
+++ b/Classes/EelHelper/SuggestionIndexHelper.php
@@ -14,6 +14,7 @@ namespace Flowpack\SearchPlugin\EelHelper;
  */
 
 use Flowpack\SearchPlugin\Exception;
+use Flowpack\SearchPlugin\Utility\Sanitation;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
@@ -47,8 +48,9 @@ class SuggestionIndexHelper implements ProtectedContextAwareInterface
     {
         $process = static function (?string $input) {
             $input = preg_replace("/\r|\n/", '', $input);
-            return array_values(array_filter(explode(' ', preg_replace("/[^[:alnum:][:space:]]/u", ' ', strip_tags($input)))));
+            return array_values(array_filter(explode(' ', Sanitation::sanitizeSearchInput(strip_tags($input)))));
         };
+
         if (\is_string($input)) {
             return $process($input);
         } elseif (\is_array($input)) {

--- a/Classes/Utility/Sanitation.php
+++ b/Classes/Utility/Sanitation.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\SearchPlugin\Utility;
+
+/*
+ * This file is part of the Flowpack.SearchPlugin package.
+ *
+ * (c) Contributors of the Flowpack Team - flowpack.org
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class Sanitation
+{
+
+    public static function sanitizeSearchInput(string $input): string
+    {
+        return str_replace(['=', '>', '<', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/'], ['', '', '', '(', '\)', '\{', '\}', '[', '\]', '\^', '\"', '\~', '\*', '\?', '\:', '\\\\', '\/'], $input);
+    }
+
+}


### PR DESCRIPTION
The previously used `[[:^alnum:]]` strips german umlauts and valid characters of other languages which leads to strange query results.

This is more fine grained approach to sanitize the search word based on elasticsearch recommendations.