### PR TITLE
BUGFIX: Remove special characters completely

### DIFF
--- a/Classes/Utility/SearchTerm.php
+++ b/Classes/Utility/SearchTerm.php
@@ -18,7 +18,7 @@ class SearchTerm
 
     public static function sanitizeSearchInput(string $input): string
     {
-        return str_replace(['=', '>', '<', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/'], ['', '', '', '(', '\)', '\{', '\}', '\[', '\]', '\^', '\"', '\~', '\*', '\?', '\:', '\\\\', '\/'], $input);
+        return str_replace(['\\', '=', '>', '<', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/'], '', $input);
     }
 
 }


### PR DESCRIPTION
According to https://lucene.apache.org/core/3_4_0/queryparsersyntax.html#Escaping%20Special%20Characters, special characters should be escapeable using a „\“ character. Sadly because of some internal json encoding this doesn’t work properly. Any of these characters break the query.