### PR TITLE
!!! BUGFIX: Contexts are respected in a multi-site environment.

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -14,6 +14,7 @@ namespace Flowpack\SearchPlugin\Controller;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException;
+use Flowpack\SearchPlugin\EelHelper\SuggestionIndexHelper;
 use Flowpack\SearchPlugin\Utility\SearchTerm;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
@@ -40,6 +41,12 @@ class SuggestController extends ActionController
      * @var VariableFrontend
      */
     protected $elasticSearchQueryTemplateCache;
+
+    /**
+     * @Flow\Inject
+     * @var SuggestionIndexHelper
+     */
+    protected $suggestionIndexHelper;
 
     /**
      * @var array
@@ -153,9 +160,7 @@ class SuggestController extends ActionController
                         'fuzzy' => true,
                         'size' => $this->searchAsYouTypeSettings['suggestions']['size'] ?? 10,
                         'contexts' => [
-                            'parent_path' => $contextNode->getPath(),
-                            'workspace' => 'live',
-                            'hidden' => false,
+                            'suggestion_context' => $this->suggestionIndexHelper->buildContext($contextNode)
                         ]
                     ]
                 ]);

--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -155,6 +155,7 @@ class SuggestController extends ActionController
                         'contexts' => [
                             'parent_path' => $contextNode->getPath(),
                             'workspace' => 'live',
+                            'hidden' => false,
                         ]
                     ]
                 ]);

--- a/Classes/EelHelper/SuggestionIndexHelper.php
+++ b/Classes/EelHelper/SuggestionIndexHelper.php
@@ -15,6 +15,7 @@ namespace Flowpack\SearchPlugin\EelHelper;
 
 use Flowpack\SearchPlugin\Exception;
 use Flowpack\SearchPlugin\Utility\SearchTerm;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
@@ -25,18 +26,36 @@ use Neos\Flow\Annotations as Flow;
  */
 class SuggestionIndexHelper implements ProtectedContextAwareInterface
 {
+
+    /**
+     * Rhe length of '/sites/'
+     * @var int
+     */
+    protected const SITES_OFFSET = 7;
+
     /**
      * @param string|array $input The input to store, this can be a an array of strings or just a string. This field is mandatory.
      * @param int $weight A positive integer or a string containing a positive integer, which defines a weight and allows you to rank your suggestions.
      * @return array
      * @throws Exception
      */
-    public function build($input, $weight = 1)
+    public function build($input, $weight = 1): array
     {
         return [
             'input' => $this->prepareInput($input),
             'weight' => $weight
         ];
+    }
+
+    public function buildContext(NodeInterface $node): string
+    {
+        $siteName = substr($node->getPath(), self::SITES_OFFSET, strpos($node->getPath() . '/', '/', self::SITES_OFFSET) - self::SITES_OFFSET);
+        return sprintf(
+            '%s-%s-%s',
+            $siteName,
+            $node->getWorkspace()->getName(),
+            $node->isHidden() ? 'hidden' : 'visible'
+        );
     }
 
     /**

--- a/Configuration/NodeTypes.Mixin.Suggestable.yaml
+++ b/Configuration/NodeTypes.Mixin.Suggestable.yaml
@@ -1,21 +1,20 @@
 'Flowpack.SearchPlugin:SuggestableMixin':
   abstract: true
   properties:
+    'neos_suggestion_context':
+      search:
+        elasticSearchMapping:
+          type: keyword
+        indexing: "${Flowpack.SearchPlugin.Suggestion.buildContext(node)}"
+
     'neos_suggestion':
       search:
         elasticSearchMapping:
           type: completion
           contexts:
             -
-              name: 'workspace'
+              name: 'suggestion_context'
               type: category
-              path: 'neos_workspace'
-            -
-              name: 'parent_path'
-              type: category
-              path: 'neos_parent_path'
-            -
-              name: 'hidden'
-              type: category
-              path: 'neos_hidden'
+              path: 'neos_suggestion_context'
+
         indexing: "${Flowpack.SearchPlugin.Suggestion.build(q(node).property('title') ? q(node).property('title') : '', 20)}"


### PR DESCRIPTION
Multiple contexts are treaded as disjunction. That means, nodes are suggested if they either are in the live workspace
or from the requested site, which makes the site restriction worthless.

This fix merges the site, workspace and hidden state into one context and uses that for filtering.

Fixes: #54