### PR TITLE
Fix searchHitForNode not callable in untrusted context

### DIFF
--- a/Resources/Private/Fusion/Helper/SearchResultrenderer/SearchresultRenderer.fusion
+++ b/Resources/Private/Fusion/Helper/SearchResultrenderer/SearchresultRenderer.fusion
@@ -4,5 +4,5 @@ prototype(Flowpack.SearchPlugin:SearchResultRenderer) < prototype(Neos.Fusion:Co
     itemRenderer = Flowpack.SearchPlugin:SingleResult
     itemName = 'node'
     // we also make the full ElasticSearch hit available to nested rendering, if possible
-    itemRenderer.@context.searchHit = ${searchResults.searchHitForNode(node)}
+    itemRenderer.@context.searchHit = ${Configuration.setting('Neos.Fusion.defaultContext.SearchResult') != NULL ? searchResults.searchHitForNode(node) : false}
 }


### PR DESCRIPTION
When using SimpleSearch.ContentRepositoryAdapter the Eel-Helper for SearchResults does not exists. NEOS runs into an error that searchHitForNode is not callable in untrusted context. To fix this i check for the Configuration-Path.