### PR TITLE
WIP: BUGFIX: Use content-repository-search version 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Plugin for search integration via content node",
     "require": {
         "neos/content-repository": "^4.0 || ^5.0",
-        "neos/content-repository-search": "^3.0 || dev-master",
+        "neos/content-repository-search": "^3.0 || ^4.0 || dev-master",
         "neos/eel": "^5.0 || ^6.0",
         "neos/flow": "^5.0 || ^6.0",
         "neos/fusion": "^4.0 || ^5.0",


### PR DESCRIPTION
As we had an issue in the neos/content-repository-search repository with version constraints,
it was not possible to use the package in the latest compatible version with neos 4.3.

So this adds 4.0 also as permitted version.

Resolves: #57